### PR TITLE
Formatting cleanup & CI dependency bumps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
@@ -57,7 +57,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@latest
       - uses: julia-actions/cache@v2
       - name: Install dependencies

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TimeArrays"
 uuid = "058eeebf-2231-41de-8410-62311c15f51e"
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,4 +1,4 @@
-# arithmetic
+#__ arithmetic
 
 """
     ta_mergewith(f, l_array::TimeArray, r_array::TimeArray; kw...) -> TimeArray

--- a/src/array.jl
+++ b/src/array.jl
@@ -1,4 +1,4 @@
-# array
+#__ array
 
 """
     replace(t_array::TimeArray, old_new::Pair...; [, count]) -> TimeArray

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,4 +1,4 @@
-# interface
+#__ interface
 
 #__ TimeTick
 
@@ -397,7 +397,7 @@ function TimeArray(timestamp::AbstractVector{T}, values::AbstractVector{V}) wher
 end
 
 """
-    TimeArray(x; timestamp::Symbol=:timestamp, value::Symbol=:value)
+    TimeArray(x; timestamp::Symbol = :timestamp, value::Symbol = :value)
 
 Creates a `TimeArray` from a Tables.jl compatible source or from an iterable.
 
@@ -423,7 +423,7 @@ julia> # From iterable
  TimeTick(2024-01-02, 2.0)
 ```
 """
-function TimeArray(x; timestamp::Symbol=:timestamp, value::Symbol=:value)
+function TimeArray(x; timestamp::Symbol = :timestamp, value::Symbol = :value)
     if Tables.istable(x)
         cols = Tables.columns(x)
         timestamps = Tables.getcolumn(cols, timestamp)

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -1,4 +1,4 @@
-# reduce
+#__ reduce
 
 function Base.reduce(f::Function, t_array::AbstractVector{TimeTick{T,V}}; kw...) where {T,V}
     return reduce(f, map(ta_value, t_array; kw...))

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -1,4 +1,4 @@
-# resample
+#__ resample
 
 #__ TimeGrid
 

--- a/src/rolling.jl
+++ b/src/rolling.jl
@@ -1,4 +1,4 @@
-# rolling
+#__ rolling
 
 """
     ta_rolling(f::Function, t_array::TimeArray, n::Int; kw...) -> TimeArray

--- a/src/sample_data.jl
+++ b/src/sample_data.jl
@@ -1,4 +1,4 @@
-# sample_data
+#__ sample_data
 
 export ta_price_sample_data,
     ta_low_price_sample_data,

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,4 +1,4 @@
-# Tables.jl interface for TimeArrays
+#__ Tables
 
 import Tables
 
@@ -57,7 +57,7 @@ end
 Base.length(iter::TimeArrayRowIterator) = length(iter.ta)
 Base.eltype(::TimeArrayRowIterator{T,V}) where {T,V} = TimeArrayRow{T,V}
 
-function Base.iterate(iter::TimeArrayRowIterator, state=1)
+function Base.iterate(iter::TimeArrayRowIterator, state = 1)
     if state > length(iter.ta)
         return nothing
     end


### PR DESCRIPTION
## Summary
- Bump patch version 1.4.0 → 1.4.1
- Fix kwarg spacing in `interface.jl` and `tables.jl`
- Bump actions/checkout from 5 to 6

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)