### PR TITLE
Add missing Tables compat entry to Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,4 +9,5 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Statistics = "1"
+Tables = "1"
 julia = "1.8"


### PR DESCRIPTION
## Summary
- Added `Tables = "1"` to the `[compat]` section of `Project.toml`
- The `Tables` package was listed in `[deps]` but had no corresponding compat entry, which can cause issues with package resolution and is flagged by Julia's package ecosystem tooling

## Details
The `Tables` dependency (uuid `bd369af6-aec1-5ad0-b16a-f7cc5008161c`) was present in `[deps]` but missing from `[compat]`. This adds the standard compat bound of `"1"` for the Tables.jl interface package.